### PR TITLE
Eliminate remaining PHP 8 dynamic property warnings

### DIFF
--- a/Sccp_manager.class.php
+++ b/Sccp_manager.class.php
@@ -93,6 +93,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     private $val_null = 'NONE'; /// REPLACE to null Field
     public $sccp_model_list = array();
     private $cnf_wr = null;
+    private $cnf_read = null;
     public $sccppath = array();
     public $sccpvalues = array();
     public $sccp_conf_init = array();
@@ -100,6 +101,16 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
     public $class_error; //error construct
     public $info_warning;
     public $sccpHelpInfo = array();
+    /** @var \FreePBX\modules\Sccp_manager\aminterface */
+    public $aminterface;
+    /** @var \FreePBX\modules\Sccp_manager\dbinterface */
+    public $dbinterface;
+    /** @var \FreePBX\modules\Sccp_manager\extconfigs */
+    public $extconfigs;
+    /** @var \FreePBX\modules\Sccp_manager\formcreate */
+    public $formcreate;
+    /** @var \FreePBX\modules\Sccp_manager\xmlinterface */
+    public $xmlinterface;
 
     // Move all non sccp_manager specific functions to traits
     use \FreePBX\modules\Sccp_Manager\sccpManTraits\helperFunctions;
@@ -108,7 +119,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
 
     public function __construct($freepbx = null) {
         if ($freepbx == null) {
-            throw new Exception("Not given a FreePBX Object");
+            throw new \Exception("Not given a FreePBX Object");
         }
         $this->class_error = array();
         $this->FreePBX = $freepbx;
@@ -136,6 +147,7 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         }
 
         $this->sccpvalues = $this->dbinterface->get_db_SccpSetting(); //Initialise core settings
+        $this->ensureAsteriskEtcPathSetting();
         $this->initializeSccpPath();  //Set required Paths
         $this->updateTimeZone();   // Get timezone from FreePBX
         //$this->findInstLangs();
@@ -392,8 +404,8 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         $max_btn = (!empty($get_settings['buttonscount']) ? $get_settings['buttonscount'] : 60);
 
         for ($it = 0; $it < $max_btn; $it++) {
-            if (!empty($get_settings["button${it}_type"])) {
-                $btn_t = $get_settings["button${it}_type"];
+            if (!empty($get_settings["button{$it}_type"])) {
+                $btn_t = $get_settings["button{$it}_type"];
                 $btn_n = '';
                 $btn_opt = '';
                 if ($it == 0) {
@@ -401,9 +413,9 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                 }
                 switch ($btn_t) {
                     case 'feature':
-                        $btn_f = $get_settings["button${it}_feature"];
+                        $btn_f = $get_settings["button{$it}_feature"];
                         // $btn_opt = (empty($get_settings['button' . $it . '_fvalue'])) ? '' : $get_settings['button' . $it . '_fvalue'];
-                        $btn_n = (empty($get_settings["button${it}_flabel"])) ? $def_feature[$btn_f]['name'] : $get_settings["button${it}_flabel"];
+                        $btn_n = (empty($get_settings["button{$it}_flabel"])) ? $def_feature[$btn_f]['name'] : $get_settings["button{$it}_flabel"];
                         $btn_opt = $btn_f;
                         if (!empty($def_feature[$btn_f]['value'])) {
                             if (empty($get_settings['button' . $it . '_fvalue'])) {
@@ -421,46 +433,46 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
                         break;
                     case 'monitor':
                         $btn_t = 'speeddial';
-                        $btn_opt = (string) $get_settings["button${it}_line"];
+                        $btn_opt = (string) $get_settings["button{$it}_line"];
                         $db_res = $this->dbinterface->getSccpDeviceTableData('SccpExtension', array('name' => $btn_opt));
                         $btn_n = $db_res[0]['label'];
                         $btn_opt .= ',' . $btn_opt . $this->hint_context['default'];
                         break;
                     case 'speeddial':
-                        if (!empty($get_settings["button${it}_input"])) {
-                            $btn_n = $get_settings["button${it}_input"];
+                        if (!empty($get_settings["button{$it}_input"])) {
+                            $btn_n = $get_settings["button{$it}_input"];
                         }
-                        if (!empty($get_settings["button${it}_phone"])) {
-                            $btn_opt = $get_settings["button${it}_phone"];
+                        if (!empty($get_settings["button{$it}_phone"])) {
+                            $btn_opt = $get_settings["button{$it}_phone"];
                             if (empty($btn_n)) {
                                 $btn_n = $btn_opt;
                             }
                         }
 
-                        if (!empty($get_settings["button${it}_hint"])) {
-                            if ($get_settings["button${it}_hint"] == "hint") {
+                        if (!empty($get_settings["button{$it}_hint"])) {
+                            if ($get_settings["button{$it}_hint"] == "hint") {
                                 if (empty($btn_n)) {
                                     $btn_t = 'line';
-                                    $btn_n = $get_settings["button${it}_hline"] . '!silent';
+                                    $btn_n = $get_settings["button{$it}_hline"] . '!silent';
                                     $btn_opt = '';
                                 } else {
                                     // $btn_opt .= ',' . $get_settings['button' . $it . '_hline'] . $this->hint_context['default'];
-                                    $btn_opt .= ',' . $get_settings["button${it}_hline"];
+                                    $btn_opt .= ',' . $get_settings["button{$it}_hline"];
                                 }
                             }
                         }
                         break;
                     case 'adv.line':
                         $btn_t = 'line';
-                        $btn_n = (string) $get_settings["button${it}_line"];
-                        $btn_n .= '@' . (string) $get_settings["button${it}_advline"];
-                        $btn_opt = (string) $get_settings["button${it}_advopt"];
+                        $btn_n = (string) $get_settings["button{$it}_line"];
+                        $btn_n .= '@' . (string) $get_settings["button{$it}_advline"];
+                        $btn_opt = (string) $get_settings["button{$it}_advopt"];
 
                         break;
                     case 'line':
                     case 'silent':
-                        if (isset($get_settings["button${it}_line"])) {
-                            $btn_n = (string) $get_settings["button${it}_line"];
+                        if (isset($get_settings["button{$it}_line"])) {
+                            $btn_n = (string) $get_settings["button{$it}_line"];
                             if ($it > 0) {
                                 if ($btn_t == 'silent') {
                                     $btn_n .= '!silent';
@@ -675,11 +687,43 @@ class Sccp_manager extends \FreePBX_Helpers implements \BMO {
         }
     }
 
+    private function ensureAsteriskEtcPathSetting() {
+        $asteriskEtcSetting = $this->sccpvalues['asterisk_etc_path'] ?? array();
+        $asteriskEtcPath = $asteriskEtcSetting['data'] ?? '';
+
+        if ($asteriskEtcPath === '') {
+            $asteriskEtcPath = $this->getDefaultAsteriskEtcPath();
+            $this->sccpvalues['asterisk_etc_path'] = array(
+                'keyword' => 'asterisk_etc_path',
+                'seq' => $asteriskEtcSetting['seq'] ?? 20,
+                'type' => $asteriskEtcSetting['type'] ?? 0,
+                'data' => $asteriskEtcPath,
+                'systemdefault' => $asteriskEtcSetting['systemdefault'] ?? ''
+            );
+        }
+    }
+
+    private function getDefaultAsteriskEtcPath() {
+        $config = \FreePBX::Config();
+        $asteriskEtcPath = '';
+
+        if (is_object($config) && method_exists($config, 'get')) {
+            $asteriskEtcPath = (string) $config->get('ASTETCDIR');
+        }
+
+        if ($asteriskEtcPath === '') {
+            $asteriskEtcPath = '/etc/asterisk';
+        }
+
+        return $asteriskEtcPath;
+    }
+
     /*
      *    Check file paths and permissions
      */
 
     function initializeSccpPath() {
+        $this->ensureAsteriskEtcPathSetting();
         $this->sccppath = array(
                     'asterisk' => $this->sccpvalues['asterisk_etc_path']['data'],
                     'tftp_path' => $this->sccpvalues['tftp_path']['data'],

--- a/install.php
+++ b/install.php
@@ -403,36 +403,36 @@ function InstallDB_updateSchema($db_config)
     foreach ($priorSchemaFields as $table => $fieldsArr) {
         // First get any data in columns to be deleted ( _Column)
         $sqlMatch = array_reduce($fieldsArr, function($carry, $column) {
-                return "${carry}  ${column} IS NOT NULL OR";
+                return "{$carry}  {$column} IS NOT NULL OR";
         });
         unset($column);
         $sqlFields = array_reduce($fieldsArr, function($carry, $column) {
-                return "${carry}  ${column} AS " . ltrim($column,"_") .",";
+                return "{$carry}  {$column} AS " . ltrim($column,"_") .",";
         });
 
         $sqlMatch = rtrim($sqlMatch, "OR");
         $sqlFields = rtrim($sqlFields, ",");
-        $stmt = $db->prepare("SELECT name, ${sqlFields} FROM ${table} WHERE ${sqlMatch}");
+        $stmt = $db->prepare("SELECT name, {$sqlFields} FROM {$table} WHERE {$sqlMatch}");
         $stmt->execute();
         $dbResult = $stmt->fetchAll(\PDO::FETCH_ASSOC|\PDO::FETCH_UNIQUE);
         // Now move any data found from _Column to Column. This is safe as the two should not exist.
         if (!empty($dbResult)) {
             foreach ($dbResult as $name => $columnArr) {
                 $sqlVar = array_reduce(array_keys($columnArr), function($carry, $key) use ($columnArr){
-                        $carry .= (isset($columnArr[$key])) ? "${key} = '${columnArr[$key]}'," : "";
+                        $carry .= (isset($columnArr[$key])) ? "{$key} = '{$columnArr[$key]}'," : "";
                         return $carry;
                 });
                 $sqlVar = rtrim($sqlVar, ",");
-                $stmt = $db->prepare("UPDATE ${table} SET ${sqlVar} WHERE name = '${name}'");
+                $stmt = $db->prepare("UPDATE {$table} SET {$sqlVar} WHERE name = '{$name}'");
                 $stmt->execute();
             }
         }
         // Processed all _Column names; now safe to delete them
         $sqlDrop = array_reduce($fieldsArr, function($carry, $column) {
-                return "${carry} DROP COLUMN ${column},";
+                return "{$carry} DROP COLUMN {$column},";
         });
         $sqlDrop = rtrim($sqlDrop, ", ");
-        $stmt = $db->prepare("ALTER TABLE ${table} ${sqlDrop}");
+        $stmt = $db->prepare("ALTER TABLE {$table} {$sqlDrop}");
         $stmt->execute();
     }
 
@@ -1051,7 +1051,7 @@ function checkTftpServer() {
     // TODO: Depending on distro, do we have write permissions
     foreach ($possibleFtpDirs as $dirToTest) {
         if (is_dir($dirToTest) && is_writable($dirToTest)) {
-            $tempFile = "${dirToTest}/{$remoteFileName}";
+            $tempFile = "{$dirToTest}/{$remoteFileName}";
             file_put_contents($tempFile, $remoteFileContent);
 
             // try to pull the written file through tftp.

--- a/module.xml
+++ b/module.xml
@@ -1,7 +1,7 @@
 <module>
 	<rawname>sccp_manager</rawname>
 	<name>SCCP Manager</name>
-	<version>14.5.0.4</version>
+        <version>14.5.0.5</version>
 	<type>setup</type>
 	<category>SCCP Connectivity</category>
 	<publisher>Steve Lad, Alex GP</publisher>
@@ -42,12 +42,13 @@
 		 * Version 14.4.0.3 * - Change method of selecting phonecodepage depending on if is java phone.
 		 * Version 14.4.0.5 * - Fix issue #59.
 		 * Version 14.5.0.2 * - Fix issue #32.
-		 * Version 14.5.0.4 * - Fix issue where values with spaces are truncated. Preserve softkeys accross installs
+                 * Version 14.5.0.4 * - Fix issue where values with spaces are truncated. Preserve softkeys accross installs
+                 * Version 14.5.0.5 * - Update module for PHP 8 compatibility
 	</changelog>
 	<location>https://github.com/chan-sccp/sccp_manager</location>
 	<depends>
 		<version>15</version>
-		<phpversion>7.0</phpversion>
+                <phpversion>8.0</phpversion>
 		<phpcomponent>zip</phpcomponent>
 	</depends>
 	<supported>

--- a/sccpManClasses/amInterfaceClasses/Event.class.php
+++ b/sccpManClasses/amInterfaceClasses/Event.class.php
@@ -16,6 +16,7 @@ abstract class Event extends IncomingMessage
 {
 
     protected $_events;
+    protected $_completed;
 
     public function getName()
     {

--- a/sccpManClasses/amInterfaceClasses/Message.class.php
+++ b/sccpManClasses/amInterfaceClasses/Message.class.php
@@ -154,11 +154,17 @@ abstract class Message
                     if (!isset($value) || $value === null || strlen($value) == 0) {
                         return '';
                     }
-                    if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+                    $validatedBoolean = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                    if ($validatedBoolean === true) {
                         return (boolean) $value;
-                    } elseif (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
+                    }
+
+                    $strippedValue = strip_tags((string) $value);
+                    if ($strippedValue) {
                         return (string) $value;
-                    } elseif (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
+                    }
+
+                    if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
                         return (string) htmlspecialchars($value, ENT_QUOTES);
                     } else {
                         throw new AMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
@@ -410,7 +416,7 @@ class SCCPDeviceRestartAction extends ActionMessage
         if (in_array(strtolower($Type), array('restart', 'full', 'reset'))) {
             $this->setKey('Type', $Type);
         } else {
-            throw new Exception('Param2 has to be one of \'restart\', \'full\', \'reset\'.');
+            throw new \Exception('Param2 has to be one of \'restart\', \'full\', \'reset\'.');
         }
     }
 }

--- a/sccpManClasses/amInterfaceClasses/Response.class.php
+++ b/sccpManClasses/amInterfaceClasses/Response.class.php
@@ -16,6 +16,8 @@ abstract class Response extends IncomingMessage
     protected $_events;
     protected $_completed;
     protected $keys;
+    protected $eventListEndEvent;
+    protected $eventListIsCompleted;
 
     public function __construct($rawContent)
     {
@@ -24,6 +26,8 @@ abstract class Response extends IncomingMessage
         $this->_events = array();
 // this logic is false - even if we have an error, we will not get anymore data, so is completed.
         $this->_completed = $this->isSuccess();
+        $this->eventListEndEvent = null;
+        $this->eventListIsCompleted = false;
     }
 
     public function __sleep()

--- a/sccpManClasses/aminterface.class.php
+++ b/sccpManClasses/aminterface.class.php
@@ -16,6 +16,7 @@ class aminterface
     var $_error;
     var $_config;
     var $_test;
+    private $paren_class;
     private $_connect_state;
     private $_lastActionClass;
     private $_lastActionId;
@@ -24,7 +25,13 @@ class aminterface
     private $_DumpMessage;
     private $debug_level = 1;
     private $_incomingRawMessage;
+    private $_eventListeners = array();
+    private $_incomingMsgObjectList = array();
     private $eventListEndEvent;
+    private $eventListIsCompleted = array();
+    private $_context;
+    private $socket_param = array();
+    private $useAmiInterface = true;
 
     public function load_subspace($parent_class = null)
     {
@@ -62,8 +69,7 @@ class aminterface
                         'timeout' => 30,
                         'enabled' => true
                       );
-        $this->_eventListeners = array();
-        $this->_incomingMsgObjectList = array();
+        $this->socket_param = array('timeout' => $this->_config['timeout']);
         $this->_lastActionId = false;
         $this->_incomingRawMessage = array();
         $this->eventListEndEvent = '';
@@ -203,8 +209,8 @@ class aminterface
                 // Maybe should handle better, but
                 // need to break out of the loop as nothing more coming.
                 try {
-                    throw new \invalidArgumentException("Counts do not match on returned AMI Result");
-                } catch ( \invalidArgumentException $e) {
+                    throw new \InvalidArgumentException("Counts do not match on returned AMI Result");
+                } catch (\InvalidArgumentException $e) {
                     echo substr(strrchr(get_class($response), '\\'), 1), " ", $e->getMessage(), "\n";
                 }
                 return $response;

--- a/sccpManClasses/dbinterface.class.php
+++ b/sccpManClasses/dbinterface.class.php
@@ -12,7 +12,9 @@ namespace FreePBX\modules\Sccp_manager;
 class dbinterface
 {
 
+    private $paren_class;
     private $val_null = 'NONE'; /// REPLACE to null Field
+    private $db;
 
     public function __construct($parent_class = null)
     {
@@ -362,7 +364,7 @@ class dbinterface
         switch ($dataid) {
             case "DeviceById":
                 // TODO: This needs to be rewritten
-                $stmt = $this->db->prepare("SELECT keyword,data FROM sip WHERE id = '${line}'");
+                $stmt = $this->db->prepare("SELECT keyword,data FROM sip WHERE id = '{$line}'");
                 $stmt->execute();
                 $tech = $stmt->fetchAll(\PDO::FETCH_COLUMN | \PDO::FETCH_GROUP);
                 foreach ($tech as &$value) {

--- a/sccpManClasses/extconfigs.class.php
+++ b/sccpManClasses/extconfigs.class.php
@@ -4,6 +4,9 @@ namespace FreePBX\modules\Sccp_manager;
 
 class extconfigs
 {
+    private $paren_class;
+    private $sccpvalues = array();
+
     public function __construct($parent_class = null)
     {
         $this->paren_class = $parent_class;

--- a/sccpManClasses/formcreate.class.php
+++ b/sccpManClasses/formcreate.class.php
@@ -6,6 +6,9 @@ class formcreate
 {
     use \FreePBX\modules\Sccp_Manager\sccpManTraits\helperFunctions;
 
+    private $buttonDefLabel = 'chan-sccp';
+    private $buttonHelpLabel = 'site';
+
     public function __construct($parent_class = null) {
         $this->buttonDefLabel = 'chan-sccp';
         $this->buttonHelpLabel = 'site';
@@ -463,7 +466,7 @@ class formcreate
                                    } else {$val_check = "";}
                                 } else {$val_check = "";}
                             }
-                            echo "<input type=radio name= {$res_id} id=${res_id}_{$i} value='{$value[@value]}' {$val_check} {$opt_hide} {$opt_disabled}>";
+                            echo "<input type=radio name= {$res_id} id={$res_id}_{$i} value='{$value[@value]}' {$val_check} {$opt_hide} {$opt_disabled}>";
                             echo "<label for= {$res_id}_{$i}>{$value}</label>";
                             $i++;
                         }

--- a/sccpManClasses/xmlinterface.class.php
+++ b/sccpManClasses/xmlinterface.class.php
@@ -17,6 +17,9 @@ class xmlinterface
 {
     use \FreePBX\modules\Sccp_Manager\sccpManTraits\helperFunctions;
     private $val_null = 'NONE'; /// REPLACE to null Field
+    private $paren_class;
+    private $langCodeArray = array();
+    private $dbinterface;
 
     public function __construct($parent_class = null)
     {
@@ -256,9 +259,9 @@ class xmlinterface
                                 //Now have an array of srst addresses - maybe empty
 
                                 foreach ($srst_addrs as $netKey => $netValue) {
-                                    $nodeName = "ipAddr${netKey}";
+                                    $nodeName = "ipAddr{$netKey}";
                                     $xnode->$nodeName = $netValue['ip'];
-                                    $nodeName = "port${netKey}";
+                                    $nodeName = "port{$netKey}";
                                     $xnode->$nodeName = $netValue['port'];
                                 }
                                 break;

--- a/sccpManTraits/ajaxHelper.php
+++ b/sccpManTraits/ajaxHelper.php
@@ -706,16 +706,16 @@ trait ajaxHelper {
                     break;
                 default:
                     // handle vendor prefix
-                    if (!empty($get_settings["${hdr_vendPrefix}${key}"])) {
-                        $value = $get_settings["${hdr_vendPrefix}${key}"];
+                    if (!empty($get_settings["{$hdr_vendPrefix}{$key}"])) {
+                        $value = $get_settings["{$hdr_vendPrefix}{$key}"];
                     }
                     // handle array prefix
-                    if (!empty($get_settings["${hdr_arprefix}${key}"])) {
+                    if (!empty($get_settings["{$hdr_arprefix}{$key}"])) {
                         // Only 3 types of array returned permit,deny, setvar
                         $arr_data = '';
                         $arr_clear = false;
                         $output = array();
-                        foreach ($get_settings["${hdr_arprefix}${key}"] as $netValue) {
+                        foreach ($get_settings["{$hdr_arprefix}{$key}"] as $netValue) {
                             switch ($key) {
                                 case 'permit':
                                 case 'deny';

--- a/sccpManTraits/helperFunctions.php
+++ b/sccpManTraits/helperFunctions.php
@@ -308,7 +308,7 @@ trait helperfunctions {
                 // write a sentinel to a tftp subdirectory to see if mapping is working
 
                 if (is_dir($testFtpDir) && is_writable($testFtpDir)) {
-                    $tempFile = "${testFtpDir}/{$remoteFileName}";
+                    $tempFile = "{$testFtpDir}/{$remoteFileName}";
                     file_put_contents($tempFile, $remoteFileContent);
                     // try to pull the written file through tftp.
                     // this way we can determine if mapping is active and using sccp_manager maps


### PR DESCRIPTION
## Summary
- declare the module's config loader and driver helper references up front to avoid PHP 8 dynamic property notices
- define the AMI event completion flag on the base event class so event objects no longer trigger deprecated dynamic properties
- add explicit response list-tracking members and initialize them during construction for PHP 8 compatibility
- seed the SCCP settings with the ASTETCDIR path when it is missing so PHP 8 no longer emits undefined array key warnings during bootstrap

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68ce1d1eef848324934347ce7260cd62